### PR TITLE
Remove Fatal log method from logger interface

### DIFF
--- a/logger/logger_interface.go
+++ b/logger/logger_interface.go
@@ -6,7 +6,6 @@ type LogOperator interface {
 	Trace(msg string)
 	Warn(msg string)
 	Error(msg string, err error)
-	Fatal(msg string, err error)
 	Panic(msg string, err error)
 	Close() error
 }

--- a/logger/zerolog_logging.go
+++ b/logger/zerolog_logging.go
@@ -146,12 +146,3 @@ func (l *ZeroLogLogger) Error(msg string, err error) {
 func (l *ZeroLogLogger) Panic(msg string, err error) {
 	l.logger.Panic().Err(err).Msg(msg)
 }
-
-// Fatal logs a fatal-level message with an error.
-//
-// Parameters:
-//   - msg: The message to be logged.
-//   - err: The error associated with the message.
-func (l *ZeroLogLogger) Fatal(msg string, err error) {
-	l.logger.Fatal().Err(err).Msg(msg)
-}


### PR DESCRIPTION
Removed the Fatal log method across logger interface, implementation, and tests. Updated tests to use a goroutine and defer mechanism for panic handling. Refactored log content check logic into a helper function for consistency.